### PR TITLE
Add explicit constructor, without or with argument. Add clear initiaization of timeout value.

### DIFF
--- a/src/RBD_Timer.cpp
+++ b/src/RBD_Timer.cpp
@@ -7,6 +7,14 @@
 #include <RBD_Timer.h> // https://github.com/alextaujenis/RBD_Timer
 
 namespace RBD {
+  Timer::Timer() {
+  }
+
+  Timer::Timer(unsigned long timeout_value)
+  {
+    _timeout = timeout_value;
+  }
+
   void Timer::setTimeout(unsigned long value) {
     _timeout = (value > 0) ? value : 1;
   }

--- a/src/RBD_Timer.h
+++ b/src/RBD_Timer.h
@@ -11,6 +11,8 @@
 namespace RBD {
   class Timer {
     public:
+      Timer();                              // Constructor with zero timeout, starting in "expired" state
+      Timer(unsigned long timeout_value);   // Constructor with the given timeout in milliseconds, starting in "expired" state
       void setTimeout(unsigned long value); // set/change how long until the timer expires in milliseconds
       void setHertz(int value);             // set/change how many times the timer can be restarted in one second
       void restart();                       // reset and start the timer
@@ -26,8 +28,8 @@ namespace RBD {
       int getPercentValue();                // how much time has passed as a percentage of the interval
       int getInversePercentValue();         // how much time is left as a percentage of the interval
     private:
-      unsigned long _timeout;               // how long this timer should run for
-      unsigned long _waypoint;              // the point in time the timer was started or reset
+      unsigned long _timeout = 0;           // how long this timer should run for
+      unsigned long _waypoint = 0;          // the point in time the timer was started or reset
       int _temp_value;                      // help constrain setHertz value
       bool _has_been_active  = false;       // helps fire the onActive event only once
       bool _has_been_expired = false;       // helps fire the onExpired event only once


### PR DESCRIPTION
A constructor is where a C++ programmer looks for finding out the initial state of the member variables. Not to have it here is rather confusing. Hence, to meet the expectation of C++ programmers using this class, having a constructor for such a non-trivial class is better than not having it. And while we're at it, a constructor with the timeout value is a useful addition since that's almost always what the user will want to do next.

Also, in the comment it should be stated what thethe initial state of a newly created timer object is. It is "expired" and not "stopped", as could have been expected, too... it took me quite a while to discover this from the code. This can be documented better.

(Personally, I'd prefer to have the initial state as "stopped" instead, but on the other hand this is just a decision, as long as it is documented enough.)
