### PR TITLE
Add get-function for the timeout member variable.

### DIFF
--- a/extras/unit_test/unit_test.ino
+++ b/extras/unit_test/unit_test.ino
@@ -37,6 +37,16 @@ RBD::Timer timer_zero;
     assertEqual(timer.getInverseValue(), 100);
   }
 
+  // setTimeout/getTimeout
+    test(getTimeout_should_return_the_timeout_in_milliseconds) {
+      timer.setTimeout(100);
+      assertEqual(timer.getTimeout(), 100);
+      timer.setTimeout(42);
+      assertEqual(timer.getTimeout(), 42);
+      timer.setTimeout(100000L); // trailing 'L' is important for 'long' literal
+      assertEqual(timer.getTimeout(), 100000L);
+    }
+
   test(setTimeout_should_constrain_the_lower_bounds_to_one_millisecond) {
     timer.setTimeout(0);
     timer.restart();

--- a/src/RBD_Timer.cpp
+++ b/src/RBD_Timer.cpp
@@ -17,6 +17,10 @@ namespace RBD {
     _timeout = (value > 0) ? value : 1;
   }
 
+  unsigned long Timer::getTimeout() const {
+    return _timeout;
+  }
+
   void Timer::setHertz(int value) {
     // possible to do: manage setHertz in micros() for higher resolution
     _temp_value = constrain(value, 1, 1000);

--- a/src/RBD_Timer.h
+++ b/src/RBD_Timer.h
@@ -14,6 +14,7 @@ namespace RBD {
       Timer();                              // constructor with zero timeout, starts in "expired" state by default
       Timer(unsigned long value);           // overloaded constructor: provide a setTimeout in milliseconds, starts in "expired" state by default
       void setTimeout(unsigned long value); // set/change how long until the timer expires in milliseconds
+      unsigned long getTimeout() const;     // Returns the value how long until the timer expires in milliseconds
       void setHertz(int value);             // set/change how many times the timer can be restarted in one second
       void restart();                       // reset and start the timer
       void stop();                          // stop the timer


### PR DESCRIPTION
In C++ it is good practice to have a get-function alongside each
set-function. In this particular case e.g. debug output might want
to return the actual timeout value of this particular timer object.

Also, a unittest for this accessor is added as well.
